### PR TITLE
Reorder compiler directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+## [0.4.1] - 2020-08-17
+- Reorder compiler directives to match single lines first (Avoid embedded parentheses triggering multi-line).
+
 ## [0.4.0] - 2020-08-15
 - Added support for TACL syntax.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "tal",
     "displayName": "Tandem TAL",
     "description": "Syntax highlighting for Transaction Application Language",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "keywords": [
         "tal",
         "tandem",

--- a/syntaxes/tal.tmLanguage.json
+++ b/syntaxes/tal.tmLanguage.json
@@ -105,6 +105,31 @@
 		"compiler_directive":{
 			"patterns": [
 				{
+					"comment": "TAL directive line. Match a single line directive line.",
+					"begin": "^(\\?)",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.preprocessor.tal"
+						}
+					},
+					"end": "$",
+					"name": "meta.preprocessor",
+					"patterns": [
+						{
+							"include": "#compiler_directive_keyword"
+						},
+						{
+							"include": "#punctuation_comma"
+						},
+						{
+							"include": "#strings"
+						},
+						{
+							"include": "#comments"
+						}
+					]
+				},
+				{
 					"comment": "Multiline TAL directive. Match multiline directive and highlight procs inside.",
 					"begin": "^(\\?)(.*)\\(",
 					"beginCaptures": {
@@ -148,31 +173,6 @@
 						},
 						{
 							"include": "#punctuation_comma"
-						}
-					]
-				},
-				{
-					"comment": "TAL directive line. Match a single line directive line.",
-					"begin": "^(\\?)",
-					"beginCaptures": {
-						"1": {
-							"name": "keyword.preprocessor.tal"
-						}
-					},
-					"end": "$",
-					"name": "meta.preprocessor",
-					"patterns": [
-						{
-							"include": "#compiler_directive_keyword"
-						},
-						{
-							"include": "#punctuation_comma"
-						},
-						{
-							"include": "#strings"
-						},
-						{
-							"include": "#comments"
 						}
 					]
 				}

--- a/syntaxes/tal.tmLanguage.json
+++ b/syntaxes/tal.tmLanguage.json
@@ -102,60 +102,65 @@
 				"1": { "name": "punctuation.accessor.tal" }
 			}
 		},
-		"compiler_directive":{
+		"compiler_directive": {
+			"comment": "TAL directive",
+			"begin": "^(\\?)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.preprocessor.tal"
+				}
+			},
+			"end": "$",
+			"name": "meta.preprocessor.tal",
 			"patterns": [
 				{
-					"comment": "TAL directive line. Match a single line directive line.",
-					"begin": "^(\\?)",
-					"beginCaptures": {
-						"1": {
-							"name": "keyword.preprocessor.tal"
-						}
-					},
-					"end": "$",
-					"name": "meta.preprocessor",
-					"patterns": [
-						{
-							"include": "#compiler_directive_keyword"
-						},
-						{
-							"include": "#punctuation_comma"
-						},
-						{
-							"include": "#strings"
-						},
-						{
-							"include": "#comments"
-						}
-					]
+					"include": "#punctuation_comma"
 				},
 				{
-					"comment": "Multiline TAL directive. Match multiline directive and highlight procs inside.",
-					"begin": "^(\\?)(.*)\\(",
-					"beginCaptures": {
+					"include": "#strings"
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#compiler_directive_keyword"
+				}
+			]
+		},
+		"compiler_directive_keyword": {
+			"patterns": [
+				{
+					"comment": "?page directive that is followed by a string",
+					"match": "(?i)\\b(?<!\\^)(page)(?!\\^)\\b\\s*(\"[^\"]*\")?",
+					"captures": {
 						"1": {
 							"name": "keyword.preprocessor.tal"
 						},
 						"2": {
-							"patterns": [
-								{
-									"include": "#compiler_directive_keyword"
-								},
-								{
-									"include": "#punctuation_comma"
-								}
-							]
+							"name": "string.quoted.double.tal"
 						}
-					},
+					}
+				},
+				{
+					"comment": "Multiline TAL directive. Match multiline directive and highlight procs inside.",
+					"begin": "\\(",
 					"end": "\\)",
-					"name": "meta.preprocessor",
+					"name": "meta.preprocessor.multiline-directive.tal",
 					"patterns": [
 						{
 							"include": "#comments"
 						},
 						{
-							"match": "^(\\?)",
-							"name": "keyword.preprocessor.tal"
+							"match": "(?i)^(\\?)\\s*\\b([a-zA-Z\\^_][a-zA-Z0-9\\^_]*)",
+							"name": "meta.function-import.tal",
+							"captures": {
+								"1": { "name": "keyword.preprocessor.tal" },
+								"2": { "name": "entity.name.function.tal" }
+							}
+						},
+						{
+							"match": "(?i)^[^\\?]?\\s*\\b([a-zA-Z\\^_][a-zA-Z0-9\\^_]*)",
+							"name": "invalid.illegal.tal"
 						},
 						{
 							"match": "(?i)\\s*\\b([a-zA-Z\\^_][a-zA-Z0-9\\^_]*)",
@@ -165,23 +170,20 @@
 							}
 						},
 						{
-							"match": "(?i)^(\\?)\\s*\\b([a-zA-Z\\^_][a-zA-Z0-9\\^_]*)",
-							"name": "meta.function-import.tal",
-							"captures": {
-								"2": { "name": "entity.name.function.tal" }
-							}
+							"match": "^(\\?)",
+							"name": "keyword.preprocessor.tal"
 						},
 						{
 							"include": "#punctuation_comma"
 						}
 					]
+				},
+				{
+					"name": "keyword.preprocessor.tal",
+					"match": "(?i)\\b(?<!\\^)(assertion|begincompilation|cpu|decs|definetog|dumpcons|(end)?if|ifnot|extendstack|compact|rp|section|source|(no)?list|(no)?code|inspect|symbols|(no)?(l)?map|gmap|(no)?crossref|innerlist|search)(?!\\^)\\b",
+					"comment": "Compiler directive keywords. Look behind to avoid matching ^keyword."
 				}
 			]
-		},
-		"compiler_directive_keyword": {
-			"name": "keyword.preprocessor.tal",
-			"match": "(?i)\\b(?<!\\^)(assertion|begincompilation|cpu|decs|definetog|dumpcons|(end)?if|ifnot|page|extendstack|compact|rp|section|source|(no)?list|(no)?code|inspect|symbols|(no)?(l)?map|gmap|(no)?crossref|innerlist|search)(?!\\^)\\b",
-			"comment": "Compiler directive keywords. Look behind to avoid matching ^keyword."
 		},
 		"comments": {
 			"patterns": [

--- a/tests/test_syntax.tal
+++ b/tests/test_syntax.tal
@@ -91,3 +91,11 @@ foo($switches bar(for)for)
 ! subproc/proc followed by ^ is incorrectly considered a procedure.
 if proc^foo = 0 then
 if subproc^foo = 0 then
+
+! Compiler directives
+! preprocessor with imbedded brackets
+?page "display time (for log records)"
+
+! multi line preprocessor
+?pushlist, nolist, source (file_OPEN_,
+?                          file_close_)


### PR DESCRIPTION
This change reorders the compiler directives matching so the single line check comes before a multi line check. 

If imbedded brackets are in a single line directive (example ?page "Some notes (extra info)") the existing code matched a multi line directive but didn't finish it. This meant the rest of the file was parsed incorrectly. 

After the change imbedded brackets are correctly handled (at least in my case).