### PR TITLE
Enhanced TACL process parsing a little

### DIFF
--- a/syntaxes/tacl.tmLanguage.json
+++ b/syntaxes/tacl.tmLanguage.json
@@ -8,6 +8,9 @@
 			"include": "#compiler_directive"
 		},
 		{
+			"include": "#defines"
+		},
+		{
 			"include": "#keywords"
 		},
 		{
@@ -306,9 +309,28 @@
 			]
 		},
 		"process": {
-			"comment": "Tandem process name \\system.$process-name",
-			"name": "constant.other.tacl",
-			"match": "(?:)(\\[a-zA-Z][a-zA-Z0-9]+\\.)?\\$[a-zA-Z][a-zA-Z0-9]+"
+			"patterns": [
+				{
+					"comment": "Special process, [\\system.]$0",
+					"name": "constant.other.tacl",
+					"match": "(?:)(\\\\[a-zA-Z][a-zA-Z0-9]{0,7}\\.)?\\$0"
+				},
+				{
+					"comment": "Special case $recieve",
+					"name": "constant.other.tacl",
+					"match": "(?:)\\$receive"
+				},
+				{
+					"comment": "Process names, [\\system.]$prcs",
+					"name": "constant.other.tacl",
+					"match": "(?:)(\\\\[a-zA-Z][a-zA-Z0-9]{0,7}\\.)?\\$[a-zA-Z][a-zA-Z0-9]{0,4}"
+				}
+			]
+		},
+		"defines": {
+			"comment": "Defines",
+			"name": "entity.name.type",
+			"match": "(?:)\\=[a-zA-Z][a-zA-Z0-9\\-\\_\\^]{1,23}"
 		},
 		"numbers": {
 			"patterns": [


### PR DESCRIPTION
- System names working
- Lengths now match Nonstop constraints ($s for example now valid)
- Special case $0, $receive handled (due to length limits)

Added defines specifically. Not part of TACL but often used, this stops the = of the define being coloured and the rest not

Let me know what you think.